### PR TITLE
Fix grantee type assignment for group permissions and remove allowFileDiscovery parameter from UserPermission and GroupPermission functions

### DIFF
--- a/drivefs.go
+++ b/drivefs.go
@@ -67,7 +67,7 @@ func (s *DriveFS) PermSet(fileID FileID, permission Permission) (permissions []P
 		case GranteeUser:
 			email, granteeType = grantee.Email, granteeTypeUser
 		case GranteeGroup:
-			email, granteeType = grantee.Email, granteeTypeUser
+			email, granteeType = grantee.Email, granteeTypeGroup
 		case GranteeDomain:
 			domain, granteeType = grantee.Domain, granteeTypeDomain
 		case GranteeAnyone:

--- a/permission.go
+++ b/permission.go
@@ -17,12 +17,12 @@ type permission struct {
 	allowFileDiscovery bool
 }
 
-func UserPermission(email string, role Role, allowFileDiscovery bool) Permission {
-	return permission{grantee: User(email), role: role, allowFileDiscovery: allowFileDiscovery}
+func UserPermission(email string, role Role) Permission {
+	return permission{grantee: User(email), role: role}
 }
 
-func GroupPermission(email string, role Role, allowFileDiscovery bool) Permission {
-	return permission{grantee: Group(email), role: role, allowFileDiscovery: allowFileDiscovery}
+func GroupPermission(email string, role Role) Permission {
+	return permission{grantee: Group(email), role: role}
 }
 
 func DomainPermission(domain string, role Role, allowFileDiscovery bool) Permission {


### PR DESCRIPTION
This pull request makes important corrections to permission handling in the `drivefs` package, specifically around group permissions and the construction of permission objects. The main changes clarify the grantee type for groups and simplify the permission constructors by removing an unused parameter.

Permission handling fixes:

* Corrected the grantee type for groups in `DriveFS.PermSet` by setting `granteeType` to `granteeTypeGroup` instead of `granteeTypeUser`, ensuring group permissions are properly identified.

Permission constructor simplification:

* Removed the `allowFileDiscovery` parameter from the `UserPermission` and `GroupPermission` constructors in `permission.go`, as it was not used in these cases.